### PR TITLE
step17 pr

### DIFF
--- a/src/main/java/com/hhdplus/concert_service/application/facade/PaymentFacade.java
+++ b/src/main/java/com/hhdplus/concert_service/application/facade/PaymentFacade.java
@@ -71,7 +71,6 @@ public class PaymentFacade {
                 String token = queue.get().getToken();
                 queueService.deleteQueue(token);
 
-                // outbox 생성 및 이벤트 send
                 PaymentEvent event = PaymentEvent.builder()
                         .userId(user.getUserId())      // 사용자 ID
                         .price(paymentResult.getAmount())      // 결제 금액
@@ -79,6 +78,9 @@ public class PaymentFacade {
                         .build();
 
                 //paymentEventPublisher.savePaymentHistory(paymentResult);
+                /*
+                    outbox 저장 이벤트 발행 후 kakfa에서 메세지 send
+                 */
                 paymentEventPublisher.createOutboxMessage(event);
                 paymentEventPublisher.sendMessage(event);
 

--- a/src/main/java/com/hhdplus/concert_service/infrastructure/implement/PaymentOutboxRepositoryImpl.java
+++ b/src/main/java/com/hhdplus/concert_service/infrastructure/implement/PaymentOutboxRepositoryImpl.java
@@ -22,7 +22,7 @@ public class PaymentOutboxRepositoryImpl implements PaymentMessageOutboxWriter {
 
     private final PaymentOutboxJpaRepository jpaRepository;
 
-    // outbox -> init으로 저장
+    // PaymentEventListener -> createOutboxMessage(PaymentEvent event) 실행
     @Override
     public PaymentOutbox save(PaymentMessage message) throws JsonProcessingException {
         PaymentOutbox entity = new PaymentOutbox();

--- a/src/main/java/com/hhdplus/concert_service/infrastructure/implement/PaymentOutboxRepositoryImpl.java
+++ b/src/main/java/com/hhdplus/concert_service/infrastructure/implement/PaymentOutboxRepositoryImpl.java
@@ -34,7 +34,7 @@ public class PaymentOutboxRepositoryImpl implements PaymentMessageOutboxWriter {
         return jpaRepository.save(entity);
     }
 
-    // outbox -> published로 저장(컨슈머에서 실행)
+    // PaymentMessageConsumer -> complete(String message) 실행
     @Override
     public PaymentOutbox complete(PaymentMessage message) {
         PaymentOutbox entity = jpaRepository.findById(message.getId()).orElseThrow();

--- a/src/main/java/com/hhdplus/concert_service/infrastructure/kafka/PaymentKafkaMessageSender.java
+++ b/src/main/java/com/hhdplus/concert_service/infrastructure/kafka/PaymentKafkaMessageSender.java
@@ -19,7 +19,7 @@ public class PaymentKafkaMessageSender implements PaymentMessageSender {
     @Autowired
     private ObjectMapper objectMapper;
 
-    // 이벤트 send
+    // PaymentEventListener -> sendMessage(PaymentEvent event) 실행
     @Override
     public void send(PaymentMessage message) throws JsonProcessingException, InterruptedException, ExecutionException {
         String PAYMENT_TOPIC = "Payment";

--- a/src/main/java/com/hhdplus/concert_service/interfaces/consumer/payment/PaymentMessageConsumer.java
+++ b/src/main/java/com/hhdplus/concert_service/interfaces/consumer/payment/PaymentMessageConsumer.java
@@ -19,6 +19,7 @@ public class PaymentMessageConsumer {
         this.paymentMessageOutboxWriter = paymentMessageOutboxWriter;
     }
 
+    // kafka에서 메세지 send 시 실행
     @KafkaListener(topics = "Payment", groupId = "group_1")
     void complete(String message) throws JsonProcessingException {
         PaymentMessage paymentMessage = objectMapper.readValue(message, PaymentMessage.class);

--- a/src/main/java/com/hhdplus/concert_service/interfaces/event/payment/PaymentEventListener.java
+++ b/src/main/java/com/hhdplus/concert_service/interfaces/event/payment/PaymentEventListener.java
@@ -36,6 +36,7 @@ public class PaymentEventListener {
         paymentService.savePaymentHistory(PaymentHistory.toDomain(paymentsHistory));
     }
 
+    // PaymentFacade의 paymentEventPublisher.createOutboxMessage(event) 실행
     @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
     public void createOutboxMessage(PaymentEvent event) throws JsonProcessingException {
         PaymentMessage message = PaymentMessage.builder()
@@ -47,6 +48,7 @@ public class PaymentEventListener {
         paymentMessageOutboxWriter.save(message);
     }
 
+    // PaymentFacade의 sendMessage(PaymentEvent event) 실행
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void sendMessage(PaymentEvent event) throws JsonProcessingException, InterruptedException, ExecutionException {

--- a/src/main/java/com/hhdplus/concert_service/interfaces/scheduler/PaymentRetryScheduler.java
+++ b/src/main/java/com/hhdplus/concert_service/interfaces/scheduler/PaymentRetryScheduler.java
@@ -30,6 +30,7 @@ public class PaymentRetryScheduler {
     @Autowired
     private ObjectMapper objectMapper;
 
+    // outbox의 status가 init 상태인 메세지를 찾아 send 후 published로 status 변경
     @Scheduled(fixedRate = 60000) // 1분마다 실행
     public void retryPendingMessages() {
         List<PaymentOutbox> pendingMessages = paymentMessageOutboxWriter.findByStatus("INIT");

--- a/src/test/java/com/hhdplus/concert_service/integrationTest/PaymentIntegrationTest.java
+++ b/src/test/java/com/hhdplus/concert_service/integrationTest/PaymentIntegrationTest.java
@@ -143,10 +143,10 @@ class PaymentIntegrationTest {
         // 큐가 삭제되었는지 확인
         assertThat(queueJpaRepository.findById("test-token")).isEmpty();
 
-        // 아웃박스에 메시지가 "INIT" 상태로 저장되었는지 확인
         List<PaymentOutbox> outboxMessages = paymentOutboxJpaRepository.findAll();
         assertThat(outboxMessages).isNotEmpty();
 
+        // 아웃박스에 메시지가 "INIT" 상태로 저장되었는지 확인
         PaymentOutbox savedMessage = outboxMessages.get(0);
         assertThat(savedMessage.getStatus()).isEqualTo("INIT");
     }

--- a/src/test/java/com/hhdplus/concert_service/integrationTest/PaymentIntegrationTest.java
+++ b/src/test/java/com/hhdplus/concert_service/integrationTest/PaymentIntegrationTest.java
@@ -162,17 +162,17 @@ class PaymentIntegrationTest {
                 .build();
         paymentMessageOutboxWriter.save(message);
 
-        // 아웃박스에 저장된 메시지 조회
+        // 아웃박스에 저장된 메시지 조회.
         List<PaymentOutbox> outboxMessages = paymentOutboxJpaRepository.findAll();
         assertThat(outboxMessages).isNotEmpty();
 
         PaymentOutbox sentMessage = outboxMessages.get(0);
         assertThat(sentMessage.getStatus()).isEqualTo("INIT");
 
-        // 메시지를 발행하는 로직을 직접 실행하여 상태를 변경
+        // 메시지를 발행하는 로직을 직접 실행하여 상태를 변경.
         paymentMessageSender.send(message);
 
-        // 상태가 "PUBLISHED"로 변경되었는지 확인
+        // 상태가 "PUBLISHED"로 변경되었는지 확인.
         PaymentOutbox updatedMessage = paymentOutboxJpaRepository.findById(message.getId()).orElseThrow();
         assertThat(updatedMessage.getStatus()).isEqualTo("PUBLISHED");
     }


### PR DESCRIPTION
- 카프카 도커 <-> 스프링부트 연동

![image](https://github.com/user-attachments/assets/78088d8d-833e-4706-822c-63e6d1996bce)

![image](https://github.com/user-attachments/assets/1075d8ba-b3dd-4051-9f88-5b8d062ab2b9)

- 카프카 consumer, producer 연동 및 테스트
1. /application/facade/PaymentFacade에서 이벤트 발행
2. /business/event/PaymentEventPublisher(IF)
3. /infrastructure/event/PaymentSpringEventPublisher
4. /interfaces/event/PaymentEventLitsener
5. /infrastructure에서 outbox 저장 및 kafka 메세지 발행
6. /interfaces/consumer/PaymentMessageConsumer에서 complete(outbox 상태변경) 수행
의 흐름으로 코드를 작성해보려고 하였습니다.
```
[PaymentFacade.java]
paymentEventPublisher.createOutboxMessage(event);
paymentEventPublisher.sendMessage(event);
```

```
[PaymentEventListener.java]
@TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
public void createOutboxMessage(PaymentEvent event) throws JsonProcessingException {
    PaymentMessage message = PaymentMessage.builder()
                .userId(event.getUserId())
                .price(event.getPrice())
                .status("INIT")
                .build();

    paymentMessageOutboxWriter.save(message);
}

@Async
@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
public void sendMessage(PaymentEvent event) throws JsonProcessingException, InterruptedException, ExecutionException {
    PaymentMessage message = PaymentMessage.builder()
                .id(event.getId())
                .userId(event.getUserId())
                .price(event.getPrice())
                .status("INIT")
                .build();

    paymentMessageSender.send(message);
}
```
그런데 위의 코드에서 facade 코드를 실행하면 eventListener 호출이 안되지 않습니다ㅠㅠ
facade에서 직접 infrastructure의 jpa와 kafka를 호출 시 테스트는 통과하는데 eventListener가 호출이 안되는데 원인을 잘 모르겠습니다.
그리고 eventListener를 사용하는 로직에서 createOutboxMessage 후에 sendMessage를 실행하면 createOutboxMessage에서 save된 outbox의 id를 제대로 가져올 수 없다고도 생각하는데 가져올 수 있는 방법도 알려주시면 감사드리겠습니다.