### PR TITLE
step 17 pr

### DIFF
--- a/src/main/java/com/hhdplus/concert_service/application/facade/PaymentFacade.java
+++ b/src/main/java/com/hhdplus/concert_service/application/facade/PaymentFacade.java
@@ -79,7 +79,7 @@ public class PaymentFacade {
 
                 //paymentEventPublisher.savePaymentHistory(paymentResult);
                 /*
-                    outbox 저장 이벤트 발행 후 kakfa에서 메세지 send
+                    outbox 저장 이벤트 발행 후 kakfa에서 메세지 send.
                  */
                 paymentEventPublisher.createOutboxMessage(event);
                 paymentEventPublisher.sendMessage(event);

--- a/src/main/java/com/hhdplus/concert_service/infrastructure/implement/PaymentOutboxRepositoryImpl.java
+++ b/src/main/java/com/hhdplus/concert_service/infrastructure/implement/PaymentOutboxRepositoryImpl.java
@@ -22,7 +22,7 @@ public class PaymentOutboxRepositoryImpl implements PaymentMessageOutboxWriter {
 
     private final PaymentOutboxJpaRepository jpaRepository;
 
-    // PaymentEventListener -> createOutboxMessage(PaymentEvent event) 실행
+    // PaymentEventListener -> createOutboxMessage(PaymentEvent event) 실행.
     @Override
     public PaymentOutbox save(PaymentMessage message) throws JsonProcessingException {
         PaymentOutbox entity = new PaymentOutbox();

--- a/src/main/java/com/hhdplus/concert_service/infrastructure/kafka/PaymentKafkaMessageSender.java
+++ b/src/main/java/com/hhdplus/concert_service/infrastructure/kafka/PaymentKafkaMessageSender.java
@@ -19,7 +19,7 @@ public class PaymentKafkaMessageSender implements PaymentMessageSender {
     @Autowired
     private ObjectMapper objectMapper;
 
-    // PaymentEventListener -> sendMessage(PaymentEvent event) 실행
+    // PaymentEventListener -> sendMessage(PaymentEvent event) 실행.
     @Override
     public void send(PaymentMessage message) throws JsonProcessingException, InterruptedException, ExecutionException {
         String PAYMENT_TOPIC = "Payment";

--- a/src/main/java/com/hhdplus/concert_service/interfaces/event/payment/PaymentEventListener.java
+++ b/src/main/java/com/hhdplus/concert_service/interfaces/event/payment/PaymentEventListener.java
@@ -36,7 +36,7 @@ public class PaymentEventListener {
         paymentService.savePaymentHistory(PaymentHistory.toDomain(paymentsHistory));
     }
 
-    // PaymentFacade의 paymentEventPublisher.createOutboxMessage(event) 실행
+    // PaymentFacade의 paymentEventPublisher.createOutboxMessage(event) 실행.
     @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
     public void createOutboxMessage(PaymentEvent event) throws JsonProcessingException {
         PaymentMessage message = PaymentMessage.builder()
@@ -48,7 +48,7 @@ public class PaymentEventListener {
         paymentMessageOutboxWriter.save(message);
     }
 
-    // PaymentFacade의 sendMessage(PaymentEvent event) 실행
+    // PaymentFacade의 sendMessage(PaymentEvent event) 실행.
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void sendMessage(PaymentEvent event) throws JsonProcessingException, InterruptedException, ExecutionException {

--- a/src/test/java/com/hhdplus/concert_service/integrationTest/PaymentIntegrationTest.java
+++ b/src/test/java/com/hhdplus/concert_service/integrationTest/PaymentIntegrationTest.java
@@ -143,12 +143,9 @@ class PaymentIntegrationTest {
         // 큐가 삭제되었는지 확인
         assertThat(queueJpaRepository.findById("test-token")).isEmpty();
 
+        //// 아웃박스에 메시지가 저장되었는지 확인
         List<PaymentOutbox> outboxMessages = paymentOutboxJpaRepository.findAll();
         assertThat(outboxMessages).isNotEmpty();
-
-        // 아웃박스에 메시지가 "INIT" 상태로 저장되었는지 확인
-        PaymentOutbox savedMessage = outboxMessages.get(0);
-        assertThat(savedMessage.getStatus()).isEqualTo("INIT");
     }
 
     @Test


### PR DESCRIPTION
- 카프카 도커 <-> 스프링부트 연동

![image](https://github.com/user-attachments/assets/78088d8d-833e-4706-822c-63e6d1996bce)

![image](https://github.com/user-attachments/assets/1075d8ba-b3dd-4051-9f88-5b8d062ab2b9)

- 카프카 consumer, producer 연동 및 테스트
1. /application/facade/PaymentFacade에서 이벤트 발행
2. /business/event/PaymentEventPublisher(IF)
3. /infrastructure/event/PaymentSpringEventPublisher
4. /interfaces/event/PaymentEventLitsener
5. /infrastructure에서 outbox 저장 및 kafka 메세지 발행
6. /interfaces/consumer/PaymentMessageConsumer에서 complete(outbox 상태변경) 수행
의 흐름으로 코드를 작성해보려고 하였습니다.
```
[PaymentFacade.java]
paymentEventPublisher.createOutboxMessage(event);
paymentEventPublisher.sendMessage(event);
```

```
[PaymentEventListener.java]
@TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
public void createOutboxMessage(PaymentEvent event) throws JsonProcessingException {
    PaymentMessage message = PaymentMessage.builder()
                .userId(event.getUserId())
                .price(event.getPrice())
                .status("INIT")
                .build();

    paymentMessageOutboxWriter.save(message);
}

@Async
@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
public void sendMessage(PaymentEvent event) throws JsonProcessingException, InterruptedException, ExecutionException {
    PaymentMessage message = PaymentMessage.builder()
                .id(event.getId())
                .userId(event.getUserId())
                .price(event.getPrice())
                .status("INIT")
                .build();

    paymentMessageSender.send(message);
}
```
그런데 위의 코드에서 facade 코드를 실행하면 eventListener 호출이 안되지 않습니다ㅠㅠ
facade에서 직접 infrastructure의 jpa와 kafka를 호출 시 테스트는 통과하는데 eventListener가 호출이 안되는데 원인을 잘 모르겠습니다.
그리고 eventListener를 사용하는 로직에서 createOutboxMessage 후에 sendMessage를 실행하면 createOutboxMessage에서 save된 outbox의 id를 제대로 가져올 수 없다고도 생각하는데 가져올 수 있는 방법도 알려주시면 감사드리겠습니다.