### PR TITLE
step 18 pr

### DIFF
--- a/src/main/java/com/hhdplus/concert_service/application/facade/PaymentFacade.java
+++ b/src/main/java/com/hhdplus/concert_service/application/facade/PaymentFacade.java
@@ -79,7 +79,7 @@ public class PaymentFacade {
 
                 //paymentEventPublisher.savePaymentHistory(paymentResult);
                 /*
-                    outbox 저장 이벤트 발행 후 kakfa에서 메세지 send
+                    outbox 저장 이벤트 발행 후 kakfa에서 메세지 send.
                  */
                 paymentEventPublisher.createOutboxMessage(event);
                 paymentEventPublisher.sendMessage(event);

--- a/src/main/java/com/hhdplus/concert_service/infrastructure/implement/PaymentOutboxRepositoryImpl.java
+++ b/src/main/java/com/hhdplus/concert_service/infrastructure/implement/PaymentOutboxRepositoryImpl.java
@@ -22,7 +22,7 @@ public class PaymentOutboxRepositoryImpl implements PaymentMessageOutboxWriter {
 
     private final PaymentOutboxJpaRepository jpaRepository;
 
-    // PaymentEventListener -> createOutboxMessage(PaymentEvent event) 실행
+    // PaymentEventListener -> createOutboxMessage(PaymentEvent event) 실행.
     @Override
     public PaymentOutbox save(PaymentMessage message) throws JsonProcessingException {
         PaymentOutbox entity = new PaymentOutbox();

--- a/src/main/java/com/hhdplus/concert_service/infrastructure/implement/PaymentOutboxRepositoryImpl.java
+++ b/src/main/java/com/hhdplus/concert_service/infrastructure/implement/PaymentOutboxRepositoryImpl.java
@@ -34,7 +34,7 @@ public class PaymentOutboxRepositoryImpl implements PaymentMessageOutboxWriter {
         return jpaRepository.save(entity);
     }
 
-    // PaymentMessageConsumer -> complete(String message) 실행
+    // PaymentMessageConsumer -> complete(String message) 실행.
     @Override
     public PaymentOutbox complete(PaymentMessage message) {
         PaymentOutbox entity = jpaRepository.findById(message.getId()).orElseThrow();

--- a/src/main/java/com/hhdplus/concert_service/infrastructure/kafka/PaymentKafkaMessageSender.java
+++ b/src/main/java/com/hhdplus/concert_service/infrastructure/kafka/PaymentKafkaMessageSender.java
@@ -19,7 +19,7 @@ public class PaymentKafkaMessageSender implements PaymentMessageSender {
     @Autowired
     private ObjectMapper objectMapper;
 
-    // PaymentEventListener -> sendMessage(PaymentEvent event) 실행
+    // PaymentEventListener -> sendMessage(PaymentEvent event) 실행.
     @Override
     public void send(PaymentMessage message) throws JsonProcessingException, InterruptedException, ExecutionException {
         String PAYMENT_TOPIC = "Payment";

--- a/src/main/java/com/hhdplus/concert_service/interfaces/consumer/payment/PaymentMessageConsumer.java
+++ b/src/main/java/com/hhdplus/concert_service/interfaces/consumer/payment/PaymentMessageConsumer.java
@@ -19,7 +19,7 @@ public class PaymentMessageConsumer {
         this.paymentMessageOutboxWriter = paymentMessageOutboxWriter;
     }
 
-    // kafka에서 메세지 send 시 실행
+    // kafka에서 메세지 send 시 실행.
     @KafkaListener(topics = "Payment", groupId = "group_1")
     void complete(String message) throws JsonProcessingException {
         PaymentMessage paymentMessage = objectMapper.readValue(message, PaymentMessage.class);

--- a/src/main/java/com/hhdplus/concert_service/interfaces/event/payment/PaymentEventListener.java
+++ b/src/main/java/com/hhdplus/concert_service/interfaces/event/payment/PaymentEventListener.java
@@ -36,7 +36,7 @@ public class PaymentEventListener {
         paymentService.savePaymentHistory(PaymentHistory.toDomain(paymentsHistory));
     }
 
-    // PaymentFacade의 paymentEventPublisher.createOutboxMessage(event) 실행
+    // PaymentFacade의 paymentEventPublisher.createOutboxMessage(event) 실행.
     @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
     public void createOutboxMessage(PaymentEvent event) throws JsonProcessingException {
         PaymentMessage message = PaymentMessage.builder()
@@ -48,7 +48,7 @@ public class PaymentEventListener {
         paymentMessageOutboxWriter.save(message);
     }
 
-    // PaymentFacade의 sendMessage(PaymentEvent event) 실행
+    // PaymentFacade의 sendMessage(PaymentEvent event) 실행.
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void sendMessage(PaymentEvent event) throws JsonProcessingException, InterruptedException, ExecutionException {

--- a/src/main/java/com/hhdplus/concert_service/interfaces/scheduler/PaymentRetryScheduler.java
+++ b/src/main/java/com/hhdplus/concert_service/interfaces/scheduler/PaymentRetryScheduler.java
@@ -30,7 +30,7 @@ public class PaymentRetryScheduler {
     @Autowired
     private ObjectMapper objectMapper;
 
-    // outbox의 status가 init 상태인 메세지를 찾아 send 후 published로 status 변경
+    // outbox의 status가 init 상태인 메세지를 찾아 send 후 published로 status 변경.
     @Scheduled(fixedRate = 60000) // 1분마다 실행
     public void retryPendingMessages() {
         List<PaymentOutbox> pendingMessages = paymentMessageOutboxWriter.findByStatus("INIT");

--- a/src/test/java/com/hhdplus/concert_service/integrationTest/PaymentIntegrationTest.java
+++ b/src/test/java/com/hhdplus/concert_service/integrationTest/PaymentIntegrationTest.java
@@ -143,12 +143,9 @@ class PaymentIntegrationTest {
         // 큐가 삭제되었는지 확인
         assertThat(queueJpaRepository.findById("test-token")).isEmpty();
 
+        //// 아웃박스에 메시지가 저장되었는지 확인
         List<PaymentOutbox> outboxMessages = paymentOutboxJpaRepository.findAll();
         assertThat(outboxMessages).isNotEmpty();
-
-        // 아웃박스에 메시지가 "INIT" 상태로 저장되었는지 확인
-        PaymentOutbox savedMessage = outboxMessages.get(0);
-        assertThat(savedMessage.getStatus()).isEqualTo("INIT");
     }
 
     @Test

--- a/src/test/java/com/hhdplus/concert_service/integrationTest/PaymentIntegrationTest.java
+++ b/src/test/java/com/hhdplus/concert_service/integrationTest/PaymentIntegrationTest.java
@@ -159,17 +159,17 @@ class PaymentIntegrationTest {
                 .build();
         paymentMessageOutboxWriter.save(message);
 
-        // 아웃박스에 저장된 메시지 조회.
+        // 아웃박스에 저장된 메시지 조회
         List<PaymentOutbox> outboxMessages = paymentOutboxJpaRepository.findAll();
         assertThat(outboxMessages).isNotEmpty();
 
         PaymentOutbox sentMessage = outboxMessages.get(0);
         assertThat(sentMessage.getStatus()).isEqualTo("INIT");
 
-        // 메시지를 발행하는 로직을 직접 실행하여 상태를 변경.
+        // 메시지를 발행하는 로직을 직접 실행하여 상태를 변경
         paymentMessageSender.send(message);
 
-        // 상태가 "PUBLISHED"로 변경되었는지 확인.
+        // 상태가 "PUBLISHED"로 변경되었는지 확인
         PaymentOutbox updatedMessage = paymentOutboxJpaRepository.findById(message.getId()).orElseThrow();
         assertThat(updatedMessage.getStatus()).isEqualTo("PUBLISHED");
     }


### PR DESCRIPTION
- outbox pattern으로 메세지 발행
 step17에서 카프카 consumer, producer 연동 및 테스트를 해보면서
/application/facade/PaymentFacade에서 이벤트 발행 후 
-> /interfaces/consumer/PaymentMessageConsumer에서 complete(outbox 상태 init -> published 변경)까지 수행하는 방식이 outbox pattern으로 메세지 발행하는 방법이라고 생각해보았습니다.

- 메세지 발행 실패시 핸들링
 ```
@Scheduled(fixedRate = 60000) // 1분마다 실행
    public void retryPendingMessages() {
        List<PaymentOutbox> pendingMessages = paymentMessageOutboxWriter.findByStatus("INIT");

        for (PaymentOutbox message : pendingMessages) {
            try {
                // 메시지 전송
                PaymentMessage retryMessage = objectMapper.readValue(message.getMessage(), PaymentMessage.class);

                paymentMessageSender.send(retryMessage);

                logger.info("Successfully resent message with ID: " + message.getId());
            } catch (Exception e) {
                logger.error("Failed to resend message with ID: " + message.getId(), e);
            }
        }
    }
```
스케쥴러에서 메세지 상태가 init인 메세지들을 send하여 메세지 발행 실패 핸들링을 해보았습니다.
커밋 된 코드에서 샌드 후 status를 published로 수정하는 코드는 불필요하다고 생각해서 위에 코드에서 제거하였습니다. 
