### PR TITLE
step17 pr

### DIFF
--- a/src/main/java/com/hhdplus/concert_service/application/facade/PaymentFacade.java
+++ b/src/main/java/com/hhdplus/concert_service/application/facade/PaymentFacade.java
@@ -73,13 +73,9 @@ public class PaymentFacade {
                 }
                 String token = queue.get().getToken();
                 queueService.deleteQueue(token);
-
-
-
                 //paymentEventPublisher.savePaymentHistory(paymentResult);
-                /*
-                    outbox 저장 이벤트 발행 후 kakfa에서 메세지 send.
-                 */
+
+                // outbox 메세지 저장
                 PaymentMessage message = PaymentMessage.builder()
                         .userId(user.getUserId())      // 사용자 ID
                         .price(paymentResult.getAmount())      // 결제 금액
@@ -88,6 +84,7 @@ public class PaymentFacade {
 
                 PaymentOutbox saveMessage = paymentMessageOutboxWriter.save(message);
 
+                // 이벤트 발행(인프라) -> 이벤트 수신(인터페이스) -> kakfa에서 메세지 send(인프라).
                 PaymentEvent event = PaymentEvent.builder()
                         .id(saveMessage.getId())
                         .userId(user.getUserId())      // 사용자 ID

--- a/src/main/java/com/hhdplus/concert_service/infrastructure/event/PaymentSpringEventPublisher.java
+++ b/src/main/java/com/hhdplus/concert_service/infrastructure/event/PaymentSpringEventPublisher.java
@@ -26,6 +26,7 @@ public class PaymentSpringEventPublisher implements PaymentEventPublisher {
         applicationEventPublisher.publishEvent(event);
     }
 
+    // 이벤트 리스너(인터페이스) send가 되어야함.
     @Override
     public void sendMessage(PaymentEvent event) {
         applicationEventPublisher.publishEvent(event);

--- a/src/main/java/com/hhdplus/concert_service/infrastructure/implement/PaymentOutboxRepositoryImpl.java
+++ b/src/main/java/com/hhdplus/concert_service/infrastructure/implement/PaymentOutboxRepositoryImpl.java
@@ -22,7 +22,7 @@ public class PaymentOutboxRepositoryImpl implements PaymentMessageOutboxWriter {
 
     private final PaymentOutboxJpaRepository jpaRepository;
 
-    // PaymentEventListener -> createOutboxMessage(PaymentEvent event) 실행.
+    // PaymentFacade -> outbox save 실행.
     @Override
     public PaymentOutbox save(PaymentMessage message) throws JsonProcessingException {
         PaymentOutbox entity = new PaymentOutbox();

--- a/src/main/java/com/hhdplus/concert_service/infrastructure/implement/PaymentOutboxRepositoryImpl.java
+++ b/src/main/java/com/hhdplus/concert_service/infrastructure/implement/PaymentOutboxRepositoryImpl.java
@@ -34,7 +34,7 @@ public class PaymentOutboxRepositoryImpl implements PaymentMessageOutboxWriter {
         return jpaRepository.save(entity);
     }
 
-    // PaymentMessageConsumer -> complete(String message) 실행.
+    // PaymentMessageConsumer -> complete(String message) 실행
     @Override
     public PaymentOutbox complete(PaymentMessage message) {
         PaymentOutbox entity = jpaRepository.findById(message.getId()).orElseThrow();

--- a/src/main/java/com/hhdplus/concert_service/infrastructure/kafka/PaymentKafkaMessageSender.java
+++ b/src/main/java/com/hhdplus/concert_service/infrastructure/kafka/PaymentKafkaMessageSender.java
@@ -19,7 +19,7 @@ public class PaymentKafkaMessageSender implements PaymentMessageSender {
     @Autowired
     private ObjectMapper objectMapper;
 
-    // PaymentEventListener -> sendMessage(PaymentEvent event) 실행.
+    // PaymentEventListener -> sendMessage(PaymentEvent event) 실행
     @Override
     public void send(PaymentMessage message) throws JsonProcessingException, InterruptedException, ExecutionException {
         String PAYMENT_TOPIC = "Payment";

--- a/src/main/java/com/hhdplus/concert_service/interfaces/consumer/payment/PaymentMessageConsumer.java
+++ b/src/main/java/com/hhdplus/concert_service/interfaces/consumer/payment/PaymentMessageConsumer.java
@@ -19,7 +19,7 @@ public class PaymentMessageConsumer {
         this.paymentMessageOutboxWriter = paymentMessageOutboxWriter;
     }
 
-    // kafka에서 메세지 send 시 실행.
+    // kafka에서 메세지 send 시 실행
     @KafkaListener(topics = "Payment", groupId = "group_1")
     void complete(String message) throws JsonProcessingException {
         PaymentMessage paymentMessage = objectMapper.readValue(message, PaymentMessage.class);

--- a/src/main/java/com/hhdplus/concert_service/interfaces/consumer/payment/PaymentMessageConsumer.java
+++ b/src/main/java/com/hhdplus/concert_service/interfaces/consumer/payment/PaymentMessageConsumer.java
@@ -19,7 +19,7 @@ public class PaymentMessageConsumer {
         this.paymentMessageOutboxWriter = paymentMessageOutboxWriter;
     }
 
-    // kafka에서 메세지 send 시 실행
+    // kafka에서 메세지 send 시 실행.
     @KafkaListener(topics = "Payment", groupId = "group_1")
     void complete(String message) throws JsonProcessingException {
         PaymentMessage paymentMessage = objectMapper.readValue(message, PaymentMessage.class);

--- a/src/main/java/com/hhdplus/concert_service/interfaces/event/payment/PaymentEventListener.java
+++ b/src/main/java/com/hhdplus/concert_service/interfaces/event/payment/PaymentEventListener.java
@@ -48,7 +48,7 @@ public class PaymentEventListener {
         paymentMessageOutboxWriter.save(message);
     }
 
-    // PaymentFacade의 sendMessage(PaymentEvent event) 실행.
+    // PaymentFacade의 sendMessage(PaymentEvent event) 실행
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void sendMessage(PaymentEvent event) throws JsonProcessingException, InterruptedException, ExecutionException {

--- a/src/test/java/com/hhdplus/concert_service/integrationTest/PaymentIntegrationTest.java
+++ b/src/test/java/com/hhdplus/concert_service/integrationTest/PaymentIntegrationTest.java
@@ -143,7 +143,7 @@ class PaymentIntegrationTest {
         // 큐가 삭제되었는지 확인
         assertThat(queueJpaRepository.findById("test-token")).isEmpty();
 
-        //// 아웃박스에 메시지가 저장되었는지 확인
+        //// 아웃박스에 메시지가 저장되었는지 확인(메세지 저장은 성공)
         List<PaymentOutbox> outboxMessages = paymentOutboxJpaRepository.findAll();
         assertThat(outboxMessages).isNotEmpty();
     }


### PR DESCRIPTION
- 카프카 도커 <-> 스프링부트 연동

![image](https://github.com/user-attachments/assets/78088d8d-833e-4706-822c-63e6d1996bce)

![image](https://github.com/user-attachments/assets/1075d8ba-b3dd-4051-9f88-5b8d062ab2b9)

- 카프카 consumer, producer 연동 및 테스트
1. /application/facade/PaymentFacade에서 outbox 저장 및 이벤트 발행
2. /business/event/PaymentEventPublisher(IF)
3. /infrastructure/event/PaymentSpringEventPublisher
4. /interfaces/event/PaymentEventLitsener
5. /infrastructure에서 outbox 저장 및 kafka 메세지 발행
6. /interfaces/consumer/PaymentMessageConsumer에서 complete(outbox 상태변경) 수행
의 흐름으로 코드를 작성해보려고 하였습니다.
```
[PaymentFacade.java]
// 이벤트 발행(인프라) -> 이벤트 수신(인터페이스) -> kakfa에서 메세지 send(인프라).
PaymentEvent event = PaymentEvent.builder()
                      .id(saveMessage.getId())
                      .userId(user.getUserId())      // 사용자 ID
                      .price(paymentResult.getAmount())      // 결제 금액
                      .status("INIT")                      // 상태
                      .build();

paymentEventPublisher.sendMessage(event);
```

```
[PaymentEventListener.java]
@Async
@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
public void sendMessage(PaymentEvent event) throws JsonProcessingException, InterruptedException, ExecutionException {
    PaymentMessage message = PaymentMessage.builder()
                .id(event.getId())
                .userId(event.getUserId())
                .price(event.getPrice())
                .status("INIT")
                .build();

    paymentMessageSender.send(message);
}
```
그런데 위의 코드에서 facade 코드를 실행하면 eventListener로 코드가 넘어가지 않습니다ㅠㅠ
그래서 메세지가 outbox에 저장은 되지만 상태변경은 init인 상태로 테스트 진행해보았습니다.